### PR TITLE
Add script to decode raw tiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 build
 lib/binding
 npm-debug.log
+mason
+mason_packages

--- a/README.md
+++ b/README.md
@@ -88,6 +88,45 @@ To rebuild all of the raw fixtures (including the tile.mvt, tile.json, and info.
 npm run build
 ```
 
+### Debugging fixtures
+
+There are couple scripts included for debugging the fixtures as you create them.
+
+**protoc dump** allows you to dump mvt fixtures to the text-based representation supported by the google protoc tool. This can be very useful for debugging fixtures to ensure you've created what you expected (particularly for tiles designed to be invalid to parse).
+
+```bash
+$ ./scripts/dump fixtures/002/tile.mvt
+layers {
+  name: "hello"
+  features {
+    type: POINT
+    geometry: 9
+    geometry: 50
+    geometry: 34
+  }
+  extent: 4096
+  version: 2
+}
+```
+
+**raw protoc dump** allows you to dump the raw contents of a buffer. This particularly useful for tiles that don't match the vector_tile.proto format.
+
+```bash
+$ ./mason_packages/.link/bin/protoc --decode_raw < fixtures/002/tile.mvt
+3 {
+  15: 2
+  1: "hello"
+  2 {
+    2: ""
+    3: 1
+    4: "\t2\""
+  }
+  5: 4096
+}
+````
+
+
+
 ### Building docs
 
 Documentation takes two forms...

--- a/scripts/dump
+++ b/scripts/dump
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+MASON_VERSION="v0.14.2"
+PROTOBUF_VERSION="3.3.0"
+
+mkdir -p ./mason
+
+if [[ ! -f ./mason/mason ]]; then
+    curl -sSfL https://github.com/mapbox/mason/archive/${MASON_VERSION}.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./mason
+fi
+
+
+if [[ ! -f ./mason_packages/.link/bin/protoc ]]; then
+    ./mason/mason install protobuf ${PROTOBUF_VERSION}
+    ./mason/mason link protobuf ${PROTOBUF_VERSION}
+fi
+
+if [[ ! ${1:-} ]] && [[ ! -f ${1:-} ]]; then
+    echo "please pass the path to a mvt fixture to decode"
+    exit 1
+fi
+
+fixture=$1
+
+./mason_packages/.link/bin/protoc \
+  vector-tile-spec/2.1/vector_tile.proto \
+  --decode vector_tile.Tile \
+  < ${fixture}
+
+


### PR DESCRIPTION
This adds a script that can dump `mvt` fixtures to the text-based represenation supported by the google `protoc` tool. And example is:

```
$ ./scripts/dump fixtures/002/tile.mvt 
layers {
  name: "hello"
  features {
    type: POINT
    geometry: 9
    geometry: 50
    geometry: 34
  }
  extent: 4096
  version: 2
}
```

This can be very useful for debugging fixtures to ensure we've created what we expected (particularly for tiles designed to be invalid to parse).

Note: for tiles that don't match the `vector_tile.proto` we can also dump the raw bytes like:

```
$ ./mason_packages/.link/bin/protoc --decode_raw < fixtures/002/tile.mvt 
3 {
  15: 2
  1: "hello"
  2 {
    2: ""
    3: 1
    4: "\t2\""
  }
  5: 4096
}
```

@mapsam 