### PR TITLE
Fixture assert

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,9 @@ function get(id) {
   if (fixture.manipulate) {
     final.buffer = fixture.manipulate(final.buffer);
   }
+  if (fixture.test) {
+    fixture.test(final.buffer);
+  }
 
   return final;
 };

--- a/lib/readBuffer.js
+++ b/lib/readBuffer.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const fs = require('fs');
+const schema = require('protocol-buffers-schema');
+const Pbf = require('pbf');
+const Compile = require('pbf/compile');
+
+const MVT_SPEC_VERSIONS = ['1.0.0', '1.0.1', '2.0', '2.1'];
+
+module.exports = function(buffer,proto) {
+  let proto_schema;
+  if (!proto) proto = '2.1';
+  if (MVT_SPEC_VERSIONS.indexOf(proto) > -1) {
+    proto_schema = schema.parse(fs.readFileSync(`vector-tile-spec/${proto}/vector_tile.proto`, 'utf8'));
+  } else {
+    proto_schema = schema.parse(proto);
+  }
+  const mvt = Compile(proto_schema);
+  var tile = mvt.Tile.read(new Pbf(buffer));
+  return tile;
+}

--- a/src/010.js
+++ b/src/010.js
@@ -1,4 +1,6 @@
+const readBuffer = require('../lib/readBuffer');
 const util = require('../lib/util');
+const assert = require('assert');
 
 module.exports = {
   description: 'Has a key property incorrectly encoded as a type std::uint32_t.',
@@ -31,5 +33,9 @@ module.exports = {
       }
     ]
   },
-  proto: util.replace('2.1', 'repeated string keys', 'repeated uint32 keys')
+  proto: util.replace('2.1', 'repeated string keys', 'repeated uint32 keys'),
+  test: function(buffer) {
+    var tile = readBuffer(buffer,this.proto);
+    assert(tile.layers[0].keys[0] === 1);
+  }
 };


### PR DESCRIPTION
> This also raises the fairly meta question in my mind of: how do we test the fixtures? Should we have a way to assert, as part of the build process, that they contain the exactly wrong data we assume?

One quick attempt, for discussion, of the idea at #19.

The other idea I now recall @mapsam had originally was to round trip the json and test that. I also tried that (on top of this branch locally) with:

```diff
diff --git a/scripts/build.js b/scripts/build.js
index 0df10fc..7e8f05e 100644
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const mvtf = require('..');
+const readBuffer = require('../lib/readBuffer');
 
 mvtf.each(function(fixture) {
 
@@ -18,7 +19,7 @@ mvtf.each(function(fixture) {
     console.log('updating',dir);
   }
   fs.writeFileSync(mvt, fixture.buffer);
-  fs.writeFileSync(json, JSON.stringify(fixture.json, null, 2));
+  fs.writeFileSync(json, JSON.stringify(readBuffer(fixture.buffer,fixture.proto), null, 2));
   fs.writeFileSync(info, JSON.stringify({
     description: fixture.description,
     specification_reference: fixture.specification_reference,
```

And that gives the diff of the fixtures of:

```diff
diff --git a/fixtures/001/tile.json b/fixtures/001/tile.json
index 9e26dfe..fd37b08 100644
--- a/fixtures/001/tile.json
+++ b/fixtures/001/tile.json
@@ -1 +1,3 @@
-{}
\ No newline at end of file
+{
+  "layers": []
+}
\ No newline at end of file
diff --git a/fixtures/002/tile.json b/fixtures/002/tile.json
index 4999cf6..176f90d 100644
--- a/fixtures/002/tile.json
+++ b/fixtures/002/tile.json
@@ -5,6 +5,7 @@
       "name": "hello",
       "features": [
         {
+          "id": 0,
           "tags": [],
           "type": 1,
           "geometry": [
diff --git a/fixtures/003/tile.json b/fixtures/003/tile.json
index a313ebd..ab809ad 100644
--- a/fixtures/003/tile.json
+++ b/fixtures/003/tile.json
@@ -7,6 +7,7 @@
         {
           "id": 1,
           "tags": [],
+          "type": 0,
           "geometry": [
             9,
             50,
diff --git a/fixtures/004/tile.json b/fixtures/004/tile.json
index 101eb0b..9e0da3b 100644
--- a/fixtures/004/tile.json
+++ b/fixtures/004/tile.json
@@ -7,7 +7,8 @@
         {
           "id": 1,
           "tags": [],
-          "type": 1
+          "type": 1,
+          "geometry": []
         }
       ],
       "keys": [],
diff --git a/fixtures/005/tile.json b/fixtures/005/tile.json
index f9ef892..0a1e693 100644
--- a/fixtures/005/tile.json
+++ b/fixtures/005/tile.json
@@ -22,7 +22,13 @@
       ],
       "values": [
         {
-          "string_value": "world"
+          "string_value": "world",
+          "float_value": 0,
+          "double_value": 0,
+          "int_value": 0,
+          "uint_value": 0,
+          "sint_value": 0,
+          "bool_value": false
         }
       ],
       "extent": 4096
diff --git a/fixtures/007/tile.json b/fixtures/007/tile.json
index 34a5d90..192cd9b 100644
--- a/fixtures/007/tile.json
+++ b/fixtures/007/tile.json
@@ -19,11 +19,17 @@
         }
       ],
       "keys": [
-        1
+        "1"
       ],
       "values": [
         {
-          "string_value": "two"
+          "string_value": "two",
+          "float_value": 0,
+          "double_value": 0,
+          "int_value": 0,
+          "uint_value": 0,
+          "sint_value": 0,
+          "bool_value": false
         }
       ],
       "extent": 4096
diff --git a/fixtures/010/tile.json b/fixtures/010/tile.json
index 108daf3..0a9574a 100644
--- a/fixtures/010/tile.json
+++ b/fixtures/010/tile.json
@@ -23,7 +23,13 @@
       ],
       "values": [
         {
-          "string_value": "hello"
+          "string_value": "hello",
+          "float_value": 0,
+          "double_value": 0,
+          "int_value": 0,
+          "uint_value": 0,
+          "sint_value": 0,
+          "bool_value": false
         }
       ],
       "extent": 4096
```

Most of that diff above is useless noise due to defaults being used as fallback when values are not set (as expected). But it also helps highlight one problem in the fixtures if you look close:

```diff
       "keys": [
-        1
+        "1"
       ],

```

That shows that fixture `007.js` is broken: it looks like an attempt to solve what #19 now does, but is not working right.
