### PR TITLE
add raw option to script

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npm run build
 
 There are couple scripts included for debugging the fixtures as you create them.
 
-**protoc dump** allows you to dump mvt fixtures to the text-based representation supported by the google protoc tool. This can be very useful for debugging fixtures to ensure you've created what you expected (particularly for tiles designed to be invalid to parse).
+**protoc specification dump** allows you to dump mvt fixtures to the text-based representation supported by the google protoc tool. This can be very useful for debugging fixtures to ensure you've created what you expected (particularly for tiles designed to be invalid to parse).
 
 ```bash
 $ ./scripts/dump fixtures/002/tile.mvt
@@ -113,10 +113,10 @@ layers {
 }
 ```
 
-**raw protoc dump** allows you to dump the raw contents of a buffer. This particularly useful for tiles that don't match the vector_tile.proto format.
+**raw protoc dump** allows you to dump the raw contents of a buffer. This particularly useful for tiles that don't match the vector_tile.proto format and you want to view which tags are generated
 
 ```bash
-$ ./mason_packages/.link/bin/protoc --decode_raw < fixtures/002/tile.mvt
+$ ./scripts/dump fixtures/002/tile.mvt --raw
 3 {
   15: 2
   1: "hello"
@@ -128,8 +128,6 @@ $ ./mason_packages/.link/bin/protoc --decode_raw < fixtures/002/tile.mvt
   5: 4096
 }
 ````
-
-
 
 ### Building docs
 

--- a/scripts/dump
+++ b/scripts/dump
@@ -18,16 +18,41 @@ if [[ ! -f ./mason_packages/.link/bin/protoc ]]; then
     ./mason/mason link protobuf ${PROTOBUF_VERSION}
 fi
 
-if [[ ! ${1:-} ]] && [[ ! -f ${1:-} ]]; then
-    echo "please pass the path to a mvt fixture to decode"
-    exit 1
+function decode() {
+  ./mason_packages/.link/bin/protoc \
+    vector-tile-spec/2.1/vector_tile.proto \
+    --decode vector_tile.Tile \
+    < ${1}
+}
+
+function decode_raw() {
+  ./mason_packages/.link/bin/protoc --decode_raw \
+  < ${1}
+}
+
+RAW=false
+
+# https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
+for i in "$@"
+do
+case $i in
+    --raw)
+    RAW=true
+    shift
+    ;;
+    *)
+    FIXTURE="$1"
+    ;;
+esac
+done
+
+if [ -z "${FIXTURE-}" ]; then
+  echo "please pass the path to a mvt fixture to decode"
+  exit 1
 fi
 
-fixture=$1
-
-./mason_packages/.link/bin/protoc \
-  vector-tile-spec/2.1/vector_tile.proto \
-  --decode vector_tile.Tile \
-  < ${fixture}
-
-
+if [[ $RAW = true ]]; then
+  decode_raw ${FIXTURE}
+else
+  decode ${FIXTURE}
+fi


### PR DESCRIPTION
This adds the `--raw` option to the scripts/dump command so we don't have to remember the protoc path for mason packages. 

cc @springmeyer 