### PR TITLE
Add new "create" method for inline fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.0
+
+* Add `create` method to module, allowing inline fixtures to be created for faster iteration in downstream libraries.
+
 ## 3.8.0
 
 * Add new worldview fixtures:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mvtf.each(function(fixture) {
 const output = decoder(mvtf.get('043').buffer);
 
 // or you can build a fixture inline
-const { buffer } mvtf.create({
+const { buffer } = mvtf.create({
   layers: [
     {
       version: 2,

--- a/README.md
+++ b/README.md
@@ -42,6 +42,36 @@ mvtf.each(function(fixture) {
 
 // or you can get individual fixtures
 const output = decoder(mvtf.get('043').buffer);
+
+// or you can build a fixture inline
+const { buffer } mvtf.create({
+  layers: [
+    {
+      version: 2,
+      name: 'parks',
+      features: [
+        {
+          id: 10,
+          tags: [ 0, 0 ], // name: Stanley Park
+          type: 1, // point
+          geometry: [ 9, 54, 38 ]
+        },
+        {
+          id: 10,
+          tags: [ 0, 0 ], // name: Olympic
+          type: 1, // point
+          geometry: [ 9, 2, 5 ]
+        }
+      ],
+      keys: [ 'name' ],
+      values: [
+        { string_value: 'Stanley Park' },
+        { string_value: 'Olympic' }
+      ],
+      extent: 4096
+    }
+  ]
+}); // ==> Buffer()
 ```
 
 ### Non-JS interface

--- a/index.js
+++ b/index.js
@@ -88,7 +88,21 @@ function each(fn) {
   });
 }
 
+/**
+ * Create a tile buffer inline without referencing a pre-existing fixture
+ *
+ * @param {Object} definition - the JSON-style protocol buffer instructions
+ * @param {Object} [options]
+ * @param {string} [options.proto="2.1"] - optional vector tile spec version
+ */
+function create(definition, options) {
+  if (!definition) throw new Error('No definition provided to mvt-fixtures#create method.');
+  options = options || {};
+  return {
+    buffer: generateBuffer(definition, options.proto || '2.1', options)
+  }
+}
+
 module.exports = {
-  get: get,
-  each: each
+  get, each, create
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mvt-fixtures",
-  "version": "3.7.1-dev4",
+  "version": "3.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mvt-fixtures",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "A require-able test fixture suite of valid and invalid Mapbox Vector Tiles",
   "main": "index.js",
   "scripts": {

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -1,0 +1,52 @@
+const test = require('tape');
+const vt = require('@mapbox/vector-tile').VectorTile;
+const pbf = require('pbf');
+const mvtf = require('..');
+
+test('[create] failure, throws if no definition provided', (assert) => {
+  assert.throws(() => {
+    mvtf.create();
+  }, /No definition provided to mvt-fixtures#create method/);
+  assert.end();
+});
+
+test('[create] success, returns buffer even if not valid', (assert) => {
+  const { buffer } = mvtf.create({ waka: 'flocka' });
+  assert.equal(buffer.toString(), '');
+  assert.end();
+});
+
+test('[create] success, creates valid mvt', (assert) => {
+  const { buffer } = mvtf.create({
+    layers: [
+      {
+        version: 2,
+        name: 'parks',
+        features: [
+          {
+            id: 10,
+            tags: [ 0, 0 ], // name: Stanley Park
+            type: 1, // point
+            geometry: [ 9, 54, 38 ]
+          },
+          {
+            id: 10,
+            tags: [ 0, 0 ], // name: Olympic
+            type: 1, // point
+            geometry: [ 9, 2, 5 ]
+          }
+        ],
+        keys: [ 'name' ],
+        values: [
+          { string_value: 'Stanley Park' },
+          { string_value: 'Olympic' }
+        ],
+        extent: 4096
+      }
+    ]
+  });
+
+  const info = new vt(new pbf(buffer));
+  assert.equal(info.layers.parks.length, 2);
+  assert.end();
+});


### PR DESCRIPTION
Creating inline fixtures is nice for quick iteration of downstream libraries. This adds a `create` method for doing such a magical thing. Boop ✨ 

![boop](https://user-images.githubusercontent.com/1943001/174911487-56c5341f-dc40-4be6-8fbc-dca8bc18fd50.gif)

